### PR TITLE
Update Raspberry Pi tunnel URL for EU IVDR LLM

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -316,7 +316,7 @@ whitelist:
 
 # Custom Settings
 # Base URL of your Raspberry Pi IVDR API. Change here instead of editing pages.
-ivdr_pi_base_url: "https://gardening-suggestions-pose-performed.trycloudflare.com"
+ivdr_pi_base_url: "https://bow-song-addressed-insertion.trycloudflare.com"
 ivdr_model: "phi4:latest"
 
 


### PR DESCRIPTION
The previous Cloudflare quick tunnel had gone offline, causing the EU IVDR LLM Assistant on the live site to show "Pi unreachable". Restarted the tunnel on the Pi and updated `ivdr_pi_base_url` in `_config.yml` to the new URL. Verified the new endpoint returns HTTP 200 with a healthy Ollama backend.